### PR TITLE
.gitignoreにティラノスタジオのconfigファイル（下記の理由より不要と判断）を追加（練習）

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+studio_config.json


### PR DESCRIPTION
プルリクエスト作成の練習もかねて、.gitignoreファイルにstudio_config.jsonを追加しました。

studio_config.jsonについて
ティラノスタジオでindex.htmlを読み込んだときに自動で生成されるconfigファイルです
無くてもプロジェクトは読み込めますが、読み込み時に必ず生成されます
configファイルの中にはプロジェクトのパスが書き込まれるようになっています
そのため、私のPCでティラノスタジオを用いてプロジェクトを読み込んだ際に、studio_config.jsonの中身が勝手に書き換わってしまう現象が発生しました。
これでは毎回ティラノスタジオで編集する際、勝手に書き換わってしまうstudio_config.jsonをコミットから除外しなければなりません
また、PCのusernameに個人情報が含まれている場合、誤ってコミットすることによる漏洩の危険があります
そのため、studio_config.jsonをgitに追跡されないように.gitignoreに追加した次第です